### PR TITLE
Remove `>` from the code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,17 @@ To see `Spectre.Console` in action, install the
 global tool.
 
 ```
-> dotnet tool restore
+dotnet tool restore
 ```
 
 Now you can list available examples in this repository:
 
 ```
-> dotnet example
+dotnet example
 ```
 
 And to run an example:
 
 ```
-> dotnet example tables
+dotnet example tables
 ```


### PR DESCRIPTION
When copying the code block, the `>` character is included in the copied text. This causes issues when pasting the code into the terminal, as it results in a failure.

This change removes the `>` to ensure a seamless copy-and-paste experience in the terminal.