### PR TITLE
Update examples to Spectre.Console.* version 0.53.0

### DIFF
--- a/examples/Cli/Delegates/Program.cs
+++ b/examples/Cli/Delegates/Program.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -27,13 +28,13 @@ public static partial class Program
         return app.Run(args);
     }
 
-    private static int Foo(CommandContext context)
+    private static int Foo(CommandContext context, CancellationToken cancellationToken)
     {
         AnsiConsole.WriteLine("Foo");
         return 0;
     }
 
-    private static int Bar(CommandContext context, BarSettings settings)
+    private static int Bar(CommandContext context, BarSettings settings, CancellationToken cancellationToken)
     {
         for (var index = 0; index < settings.Count; index++)
         {
@@ -43,13 +44,13 @@ public static partial class Program
         return 0;
     }
 
-    private static Task<int> FooAsync(CommandContext context)
+    private static Task<int> FooAsync(CommandContext context, CancellationToken cancellationToken)
     {
         AnsiConsole.WriteLine("Foo");
         return Task.FromResult(0);
     }
 
-    private static Task<int> BarAsync(CommandContext context, BarSettings settings)
+    private static Task<int> BarAsync(CommandContext context, BarSettings settings, CancellationToken cancellationToken)
     {
         for (var index = 0; index < settings.Count; index++)
         {

--- a/examples/Cli/Demo/Commands/Add/AddPackageCommand.cs
+++ b/examples/Cli/Demo/Commands/Add/AddPackageCommand.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Threading;
 using Demo.Utilities;
 using Spectre.Console.Cli;
 
@@ -38,7 +39,7 @@ public sealed class AddPackageCommand : Command<AddPackageCommand.Settings>
         public bool Interactive { get; set; }
     }
 
-    public override int Execute(CommandContext context, Settings settings)
+    public override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
         SettingsDumper.Dump(settings);
         return 0;

--- a/examples/Cli/Demo/Commands/Add/AddReferenceCommand.cs
+++ b/examples/Cli/Demo/Commands/Add/AddReferenceCommand.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Threading;
 using Demo.Utilities;
 using Spectre.Console.Cli;
 
@@ -21,7 +22,7 @@ public sealed class AddReferenceCommand : Command<AddReferenceCommand.Settings>
         public bool Interactive { get; set; }
     }
 
-    public override int Execute(CommandContext context, Settings settings)
+    public override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
         SettingsDumper.Dump(settings);
         return 0;

--- a/examples/Cli/Demo/Commands/Run/RunCommand.cs
+++ b/examples/Cli/Demo/Commands/Run/RunCommand.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Threading;
 using Demo.Utilities;
 using Spectre.Console.Cli;
 
@@ -61,7 +62,7 @@ public sealed class RunCommand : Command<RunCommand.Settings>
         public bool Force { get; set; }
     }
 
-    public override int Execute(CommandContext context, Settings settings)
+    public override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
         SettingsDumper.Dump(settings);
         return 0;

--- a/examples/Cli/Demo/Commands/Serve/ServeCommand.cs
+++ b/examples/Cli/Demo/Commands/Serve/ServeCommand.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.Threading;
 using Demo.Utilities;
 using Spectre.Console.Cli;
 
@@ -19,7 +20,7 @@ public sealed class ServeCommand : Command<ServeCommand.Settings>
         public FlagValue<string> OpenBrowser { get; set; }
     }
 
-    public override int Execute(CommandContext context, Settings settings)
+    public override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
         if (settings.OpenBrowser.IsSet)
         {

--- a/examples/Cli/Dynamic/MyCommand.cs
+++ b/examples/Cli/Dynamic/MyCommand.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -6,7 +7,7 @@ namespace Dynamic;
 
 public sealed class MyCommand : Command
 {
-    public override int Execute(CommandContext context)
+    public override int Execute(CommandContext context, CancellationToken cancellationToken)
     {
         if (!(context.Data is int data))
         {

--- a/examples/Cli/Help/DefaultCommand.cs
+++ b/examples/Cli/Help/DefaultCommand.cs
@@ -12,7 +12,7 @@ public sealed class DefaultCommand : Command
         _console = console;
     }
 
-    public override int Execute(CommandContext context)
+    public override int Execute(CommandContext context, CancellationToken cancellationToken)
     {
         _console.WriteLine("Hello world");
         return 0;

--- a/examples/Cli/Injection/Commands/DefaultCommand.cs
+++ b/examples/Cli/Injection/Commands/DefaultCommand.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.Threading;
 using Spectre.Console.Cli;
 
 namespace Injection.Commands;
@@ -21,7 +22,7 @@ public sealed class DefaultCommand : Command<DefaultCommand.Settings>
         _greeter = greeter ?? throw new ArgumentNullException(nameof(greeter));
     }
 
-    public override int Execute(CommandContext context, Settings settings)
+    public override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
         _greeter.Greet(settings.Name);
         return 0;

--- a/examples/Cli/Logging/Commands/HelloCommand.cs
+++ b/examples/Cli/Logging/Commands/HelloCommand.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -23,7 +24,7 @@ public class HelloCommand : Command<HelloCommand.Settings>
     }
 
 
-    public override int Execute(CommandContext context, Settings settings)
+    public override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
         _logger.LogInformation("Starting my command");
         AnsiConsole.MarkupLine($"Hello, [blue]{settings.Name}[/]");

--- a/examples/Cli/Testing/CommandAppTests.cs
+++ b/examples/Cli/Testing/CommandAppTests.cs
@@ -23,7 +23,7 @@ public class CommandAppTests
             _console = console;
         }
 
-        public override int Execute(CommandContext context)
+        public override int Execute(CommandContext context, CancellationToken cancellationToken)
         {
             _console.WriteLine("Hello world.");
             return 0;

--- a/examples/Shared/Shared.csproj
+++ b/examples/Shared/Shared.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Spectre.Console" Version="0.49.1" />
-    <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
-    <PackageReference Include="Spectre.Console.ImageSharp" Version="0.49.1" />
-    <PackageReference Include="Spectre.Console.Json" Version="0.49.1" />
-    <PackageReference Include="Spectre.Console.Testing" Version="0.49.1" />
+    <PackageReference Include="Spectre.Console" Version="0.53.0" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.53.0" />
+    <PackageReference Include="Spectre.Console.ImageSharp" Version="0.53.0" />
+    <PackageReference Include="Spectre.Console.Json" Version="0.53.0" />
+    <PackageReference Include="Spectre.Console.Testing" Version="0.53.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
All the Cli examples have been updated with the new CancellationToken introduced in https://github.com/spectreconsole/spectre.console/pull/1911